### PR TITLE
Move GovCMS distribution reference to new home

### DIFF
--- a/composer.9.json
+++ b/composer.9.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "govcms/govcms-custom": "*",
-        "govcms-poc/govcms": "2.x-dev",
+        "govcms/govcms": "2.x-master-dev",
         "govcms/scaffold-tooling": "9.x-dev"
     },
     "require-dev": {


### PR DESCRIPTION
GovCMS now has a `9.x` release published, move away from the POC namespace.