### PR TITLE
[GOVCMS-5388]: Use notification wrapper for drush commands.

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -4,7 +4,7 @@ environments:
   master:
     cronjobs:
       - name: Drupal cron with notifications
-        schedule: "0 * * * *"
+        schedule: "M * * * *"
         command: '/app/vendor/bin/govcms-drush cron --root=/app'
         service: cli
 

--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -3,9 +3,9 @@ docker-compose-yaml: docker-compose.yml
 environments:
   master:
     cronjobs:
-      - name: drush cron
-        schedule: "M * * * *"
-        command: 'drush cron --root=/app'
+      - name: Drupal cron with notifications
+        schedule: "0 * * * *"
+        command: '/app/vendor/bin/govcms-drush cron --root=/app'
         service: cli
 
 # Note regarding tasks in the scaffold.


### PR DESCRIPTION
- Updates cron to utilise the wrapper provided by scaffold tooling for alerting