### PR TITLE
Merge repositories values.

### DIFF
--- a/.docker/Dockerfile.saasplus
+++ b/.docker/Dockerfile.saasplus
@@ -18,4 +18,6 @@ COPY favicon.ico /app/web
 
 # To enable SaaS+ uncomment these lines
 COPY custom /app/custom
+RUN jq -s '.[1].repositories = (.[0].repositories + .[1].repositories) | .[1]' /app/custom/composer/composer.json /app/composer.json > /tmp/composer.json
+RUN mv /tmp/composer.json /app/composer.json
 RUN rm composer.lock && composer install -d /app && composer clearcache

--- a/custom/composer/composer.json
+++ b/custom/composer/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "govcms/govcms-custom",
     "description": "Provides additional packages over the GovCMS base distribution.",
+    "repositories": [],
     "require": {
     }
 }


### PR DESCRIPTION
If a saasplus `composer.json` uses a repository other than one used in the root it will fail during dependency lookup.