### PR TITLE
[GOVCMS-7435]: Add docker-compose.override.yml to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ audit-site
 
 # Location of ship-shape XML result files.
 .ship-shape
+
+# Local development tools.
+docker-compose.override.yml


### PR DESCRIPTION
- Adds an ignore for `docker-compose.override.yml`