### PR TITLE
unblock the  user 1 before creating login uli

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -72,7 +72,9 @@ commands:
 
   login:
     usage: Login to a website.
-    cmd: docker-compose exec -T cli drush uli "$@"
+    cmd: |
+      docker-compose exec -T cli drush uinf --uid 1 --field name | xargs docker-compose exec -T cli drush uublk && \
+      docker-compose exec -T cli drush uli
 
   unloop:
     usage: Fix local redirect loop


### PR DESCRIPTION
User 1 is always blocked when buildng new instance locally. 
This update unblock and then generate uli. 

