### PR TITLE
fix: add modules from base image

### DIFF
--- a/.docker/Dockerfile.paas
+++ b/.docker/Dockerfile.paas
@@ -5,11 +5,14 @@
 ARG CLI_IMAGE
 ARG GOVCMS_IMAGE_VERSION={{ GOVCMS_VERSION }}.x-latest
 
+# Keep the base so we can copy modules from it at the end.
+FROM govcms/govcms:${GOVCMS_IMAGE_VERSION} as base
+
 FROM govcms/govcms:${GOVCMS_IMAGE_VERSION}
 
 ENV WEBROOT=web
 
-# @todo: May be removed once base image is leaner.
+# Clean up base image so as not to conflict with any changes.
 RUN rm -rf /app
 
 COPY composer.* /app/
@@ -33,6 +36,8 @@ COPY .docker/config/cli/govcms.site.yml /app/drush/sites/
 RUN wget -O /usr/local/bin/drush "https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar" \
   && chmod +x /usr/local/bin/drush \
   && rm -Rf /home/.composer/vendor/bin
+
+COPY --from=govcms/govcms:${GOVCMS_IMAGE_VERSION} /app/web/sites/all/modules/ /app/web/sites/all/modules/
 
 # Sanitize the Drupal install to remove potentially
 # harmful files from the built image.

--- a/.docker/Dockerfile.paas
+++ b/.docker/Dockerfile.paas
@@ -9,6 +9,9 @@ FROM govcms/govcms:${GOVCMS_IMAGE_VERSION}
 
 ENV WEBROOT=web
 
+# @todo: May be removed once base image is leaner.
+RUN rm -rf /app
+
 COPY composer.* /app/
 COPY scripts /app/scripts
 COPY custom /app/custom

--- a/.docker/Dockerfile.paas
+++ b/.docker/Dockerfile.paas
@@ -37,7 +37,7 @@ RUN wget -O /usr/local/bin/drush "https://github.com/drush-ops/drush-launcher/re
   && chmod +x /usr/local/bin/drush \
   && rm -Rf /home/.composer/vendor/bin
 
-COPY --from=govcms/govcms:${GOVCMS_IMAGE_VERSION} /app/web/sites/all/modules/ /app/web/sites/all/modules/
+COPY --from=base /app/web/sites/all/modules/ /app/web/sites/all/modules/
 
 # Sanitize the Drupal install to remove potentially
 # harmful files from the built image.

--- a/.docker/Dockerfile.paas
+++ b/.docker/Dockerfile.paas
@@ -9,9 +9,6 @@ FROM govcms/govcms:${GOVCMS_IMAGE_VERSION}
 
 ENV WEBROOT=web
 
-# @todo: May be removed once base image is leaner.
-RUN rm -rf /app
-
 COPY composer.* /app/
 COPY scripts /app/scripts
 COPY custom /app/custom


### PR DESCRIPTION
fixes GOVCMS-7732

Required govcms modules are added to `/app/web/sites/all` (see [here](https://github.com/govCMS/lagoon/blob/2.x-develop/.docker/Dockerfile.govcms#L51)), but the PaaS image has traditionally been removing the `/app` directory.

~~It seems like the base image is now leaner as per the comment and we can safely get rid of the line.~~

Added a line to copy the modules from the base image.