### PR TITLE
Prevent output wrapping when running "ahoy drush"

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -48,7 +48,7 @@ commands:
 
   drush:
     usage: Run drush commands in cli container.
-    cmd: docker-compose exec -T cli drush "$@"
+    cmd: docker-compose exec -e COLUMNS=120 -T cli drush "$@"
 
   logs:
     usage: Show Docker logs.

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -48,7 +48,7 @@ commands:
 
   drush:
     usage: Run drush commands in cli container.
-    cmd: docker-compose exec -e COLUMNS=120 -T cli drush "$@"
+    cmd: docker-compose exec -e -T cli drush "$@"
 
   logs:
     usage: Show Docker logs.


### PR DESCRIPTION
This is in order to address this issue:

![image](https://user-images.githubusercontent.com/2423362/173475570-2ac6fe2c-8095-4c20-98ce-052219f9a257.png)

As you can see from the screenshot above, running `ahoy drush uinf` directly returns a wrapped username/email, which is hard to copy/paste or parse via grep. Whereas first ssh'ing via `ahoy cli` and then running `drush uinf` has the correctly-formatted, expected output.

This is not an issue with ahoy, rather than with docker-compose, and it can be fixed is you specify the `COLUMNS` parameter. I've set it to 120, which basically increases it from the default 80 and seems plenty (should fix the issue in most cases):

![image](https://user-images.githubusercontent.com/2423362/173477707-833f29cc-4b73-40fa-9e94-757907d3c043.png)