### PR TITLE
fix: allow plugins for PaaS composer

### DIFF
--- a/composer.8.json
+++ b/composer.8.json
@@ -25,7 +25,15 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpstan/extension-installer": true
+        }
     },
     "autoload": {
         "classmap": [

--- a/composer.9.json
+++ b/composer.9.json
@@ -52,7 +52,15 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpstan/extension-installer": true
+        }
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
PaaS scaffolds are not working properly due to plugins not enabled. Copied the relevant bits from [govcms/lagoon](https://github.com/govCMS/lagoon/blob/10fb4c4977123c5931b6ee9ad9a95f1f48f4a89f/composer.json#L62).