### PR TITLE
[GOVCMS-8167] Revert "Prevent output wrapping when running "ahoy drush""

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -48,7 +48,7 @@ commands:
 
   drush:
     usage: Run drush commands in cli container.
-    cmd: docker-compose exec -e -T cli drush "$@"
+    cmd: docker-compose exec -T cli drush "$@"
 
   logs:
     usage: Show Docker logs.

--- a/custom/ahoy.yml
+++ b/custom/ahoy.yml
@@ -11,6 +11,10 @@ commands:
       echo -e "Type \`\033[0;32mahoy my\033[0m\` for a list of custom commmands."
       echo
 
+  drush-wo-line-wrap:
+    usage: Return the output without line wrapping.
+    cmd: docker-compose exec -e 120 -T cli drush "$@"
+
 #  mycustomcommand:
 #    cmd: |
 #      echo "Anything complex you can do on the command line, you can make available for all developers in your project."

--- a/custom/ahoy.yml
+++ b/custom/ahoy.yml
@@ -11,7 +11,7 @@ commands:
       echo -e "Type \`\033[0;32mahoy my\033[0m\` for a list of custom commmands."
       echo
 
-  drush-wo-line-wrap:
+  drush-local:
     usage: Return the output without line wrapping.
     cmd: docker-compose exec -e 120 -T cli drush "$@"
 


### PR DESCRIPTION
This change causes an issue with running drush commands in Gitlab CI because it does not currently support tty (see: https://gitlab.com/gitlab-org/gitlab-runner/-/issues/2115). 