### PR TITLE
[GOVCMS-7646] Added lagoon conditionals for deploy overrides.

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -42,9 +42,10 @@ tasks:
     ## START SaaS-only
     - run:
         name: Perform GovCMS platform validations
-        command: '[ "${GOVCMS_SKIP_AUDIT}" = "true" ] && echo "Audit skipped." || /app/vendor/bin/govcms-ship-shape -an'
+        command: /app/vendor/bin/govcms-ship-shape -an
         service: cli
         shell: bash
+        when: withDefault("GOVCMS_SKIP_AUDIT", false) == false
     ## END SaaS-only
     - run:
         name: Synchronise the database
@@ -61,6 +62,7 @@ tasks:
         command: /app/vendor/bin/govcms-config-import
         service: cli
         shell: bash
+        when: withDefault("GOVCMS_SKIP_CONFIG_IMPORT", false) == false
     - run:
         name: Perform cache rebuild
         command: /app/vendor/bin/govcms-cache-rebuild

--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -68,6 +68,7 @@ tasks:
         command: /app/vendor/bin/govcms-cache-rebuild
         service: cli
         shell: bash
+        when: withDefault("GOVCMS_SKIP_CACHE_REBUILD", false) == false
     - run:
         name: Ensure GovCMS/Lagoon modules are enabled
         command: /app/vendor/bin/govcms-enable_modules


### PR DESCRIPTION
With these conditionals, bulk deploys can now be done with straight-forward overrides allowing builds to skip the audit and config import tasks.

```graphql
mutation {
  bulkDeployEnvironmentLatest(input: {
    environments: [
      {
        buildVariables: [
          { name: "GOVCMS_SKIP_CONFIG_IMPORT" value: "true" },
          { name: "GOVCMS_SKIP_AUDIT" value: "true" }
        ]
        environment: {
          name: "master"
          project: {name: "test-bulk-deploy"}
        }
      }
    ]
  })
}
```
![image](https://user-images.githubusercontent.com/1160048/191200981-68dc2e34-23f3-49a3-9b07-f950ac3607ee.png)

