### PR TITLE
GOVCMS-5869: ClamAV support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ services:
       << : *default-environment
 
   clamav:
-    image: govcms/clamav:{{ GOVCMS_VERSION }}.x-latest}
+    image: govcms/clamav:{{ GOVCMS_VERSION }}.x-latest
     labels:
       lagoon.type: none
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ x-environment: &default-environment
   GOVCMS_DEPLOY_WORKFLOW_CONFIG: ${GOVCMS_DEPLOY_WORKFLOW_CONFIG:-import}
   GOVCMS_PREPARE_XML_SCRIPT: /app/vendor/bin/govcms-prepare-xml
   CLAMAV_HOST: clamav
+  CLAMAV_MODE: daemon
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ x-environment: &default-environment
   DRUPAL_SHIELD_PASS: ${DRUPAL_SHIELD_PASS:-}
   GOVCMS_DEPLOY_WORKFLOW_CONFIG: ${GOVCMS_DEPLOY_WORKFLOW_CONFIG:-import}
   GOVCMS_PREPARE_XML_SCRIPT: /app/vendor/bin/govcms-prepare-xml
+  CLAMAV_HOST: clamav
 
 services:
 
@@ -125,6 +126,11 @@ services:
       - "3306" # Find port on host with `docker-compose port mariadb 3306`
     environment:
       << : *default-environment
+
+  clamav:
+    image: govcms/clamav:{{ GOVCMS_VERSION }}.x-latest}
+    labels:
+      lagoon.type: none
 
   # Uncomment to enable solr.
   # solr:


### PR DESCRIPTION
- Adds a local clamav container

The ClamAV binary is being removed from the base images, to support scanning locally if required we'll bundle the clam container along with the local stack.