### PR TITLE
Change Shipshape workdir.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -129,7 +129,7 @@ commands:
   ship-shape:
     usage: Run site validation scripts locally
     cmd: |
-      docker-compose exec -T cli shipshape -f /app/vendor/govcms/scaffold-tooling/shipshape.yml --exclude-db --error-code "$@"
+      docker-compose exec -T -w /app/web cli shipshape -f /app/vendor/govcms/scaffold-tooling/shipshape.yml --exclude-db --error-code "$@"
 
   debug:
     usage: Enable debug configuration.

--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -45,7 +45,7 @@ tasks:
     ## START SaaS-only
     - run:
         name: Perform GovCMS platform validations
-        command: 'shipshape -f /app/vendor/govcms/scaffold-tooling/shipshape.yml --exclude-db --error-code'
+        command: 'cd /app/web && shipshape -f /app/vendor/govcms/scaffold-tooling/shipshape.yml --exclude-db --error-code'
         service: cli
         shell: bash
         when: withDefault("GOVCMS_SKIP_AUDIT", false) == false


### PR DESCRIPTION
# Changes
To allow shipshape to be workdir agnostic, the default config has been adjusted to feature validation checks with paths set to be relevant to the workdir set when executing shipshape command. (see [PR here](https://github.com/govCMS/scaffold-tooling/pull/235)).

This PR adds `/app/web` as workdir for validations.