### PR TITLE
Remove egulias/email-validator

### DIFF
--- a/composer.10.json
+++ b/composer.10.json
@@ -27,8 +27,7 @@
         "govcms/govcms": "3.x-master-dev",
         "govcms/scaffold-tooling": "10.x-master-dev",
         "drush/drush": "^12",
-        "composer/installers": "^2.0",
-        "egulias/email-validator": "4.0.1 as 3.2.6"
+        "composer/installers": "^2.0"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
egulias/email-validator is no longer required after removal of Swiftmailer.