### PR TITLE
Add php-http/discovery to the composer allow-plugins

### DIFF
--- a/composer.10.json
+++ b/composer.10.json
@@ -47,7 +47,8 @@
             "drupal/core-composer-scaffold": true,
             "drupal/core-project-message": true,
             "oomphinc/composer-installers-extender": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "php-http/discovery": true
         }
     },
     "autoload": {


### PR DESCRIPTION
php-http/discovery plugin is needed as part of the update to core 10.2