### PR TITLE
[GOVCMS-10295] Removed extra `COPY` from PaaS dockerfile

### DIFF
--- a/.docker/Dockerfile.paas
+++ b/.docker/Dockerfile.paas
@@ -5,9 +5,6 @@
 ARG CLI_IMAGE
 ARG GOVCMS_IMAGE_VERSION={{ GOVCMS_VERSION }}.x-latest
 
-# Keep the base so we can copy modules from it at the end.
-FROM govcms/govcms:${GOVCMS_IMAGE_VERSION} as base
-
 FROM govcms/govcms:${GOVCMS_IMAGE_VERSION}
 
 ARG GOVCMS_GITHUB_TOKEN
@@ -38,8 +35,6 @@ COPY .docker/config/cli/govcms.site.yml /app/drush/sites/
 # Remove Drush 8 in /home/.composer.
 RUN rm -Rf /home/.composer/vendor/bin
 ENV PATH="/app/vendor/bin:${PATH}"
-
-COPY --from=base /app/web/sites/all/modules/ /app/web/sites/all/modules/
 
 # Sanitize the Drupal install to remove potentially
 # harmful files from the built image.


### PR DESCRIPTION
Historically modules have been copied from the `govcms/lagoon` base images: https://github.com/govCMS/lagoon/tree/3.x-develop/modules as there were additional, required custom modules maintained here.

This is no longer the case, it should be safe to remove this extra step in the build. Tested in `sandbox/govcms-10295-test`