### PR TITLE
Fix: Remove network configuration for local containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,9 +63,6 @@ services:
     # https://pygmy.readthedocs.io/en/master/ssh_agent/
     volumes_from: ### Local overrides to mount host SSH keys. Automatically removed in CI.
       - container:amazeeio-ssh-agent ### Local overrides to mount host SSH keys. Automatically removed in CI.
-    networks:
-      - amazeeio-network
-      - default
 
   test:
     build:
@@ -82,9 +79,6 @@ services:
       - cli
     environment:
       << : *default-environment
-    networks:
-      - amazeeio-network
-      - default
 
   nginx:
     build:
@@ -122,9 +116,6 @@ services:
       - cli
     environment:
       << : *default-environment
-    networks:
-      - amazeeio-network
-      - default
 
   mariadb:
     image: ${MARIADB_DATA_IMAGE:-govcms/mariadb-drupal:{{ GOVCMS_VERSION }}.x-latest}


### PR DESCRIPTION
The following pull request will add support for pygmy mailhog particularly on mac:

https://github.com/uselagoon/lagoon-images/pull/1073

This revert will allow multiple local sites to be run.

Fixes #94