### PR TITLE
Fix: Remove additional copies.

### DIFF
--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -12,11 +12,3 @@ ENV WEBROOT=web
 
 COPY --from=cli /app /app
 COPY tests /app/tests/
-
-# Copy deploy and test scripts.
-RUN cp /app/vendor/govcms/scaffold-tooling/scripts/govcms* /usr/local/bin/
-RUN chmod +x /usr/local/bin/*
-
-# @see also drush setup in Dockerfile.cli
-COPY --from=cli /usr/local/bin/drush /usr/local/bin/
-RUN chmod +x /usr/local/bin/drush && rm -Rf /home/.composer/vendor/bin


### PR DESCRIPTION
The PHP8.3 base images move Drush and it is no longer available via `/usr/local/bin`. Drush is installed by composer and is available in the vendor directory which is copied above this continues to resolve correctly after the PHP upgrade.

```
# docker compose run test drush --version

configured lagoon-php.ini
Drush Launcher Version: 0.10.2
Drush Commandline Tool 12.5.2.0

# docker compose run test which drush

configured lagoon-php.ini
/usr/local/bin/drush
```