### PR TITLE
[DEVOPS-631] Replace clamav vars with httpav's

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,9 @@ x-environment: &default-environment
   DRUPAL_SHIELD_PASS: ${DRUPAL_SHIELD_PASS:-}
   GOVCMS_DEPLOY_WORKFLOW_CONFIG: ${GOVCMS_DEPLOY_WORKFLOW_CONFIG:-import}
   GOVCMS_PREPARE_XML_SCRIPT: /app/vendor/bin/govcms-prepare-xml
-  CLAMAV_HOST: av
-  CLAMAV_MODE: daemon
+  HTTPAV_ENDPOINT: http://av:3993/scan
+  HTTPAV_RETURN_KEY: comodo
+  HTTP_PAYLOAD_KEY: malware
 
 services:
 


### PR DESCRIPTION
Although new projects created on the GovCMS platform already had the correct environment variables, locally the ClamAV ones were still being used. This is now fixed and `httpav` will now work properly locally.