### PR TITLE
[GOVCMSD10-1102] Add plugin tbachert/spi to Scaffold

### DIFF
--- a/composer.10.json
+++ b/composer.10.json
@@ -33,8 +33,8 @@
             "oomphinc/composer-installers-extender": true,
             "phpstan/extension-installer": true,
             "php-http/discovery": true,
-            "tbachert/spi": true,
-            "simplesamlphp/composer-module-installer": true
+            "simplesamlphp/composer-module-installer": true,
+            "tbachert/spi": true
         }
     },
     "autoload": {

--- a/composer.10.json
+++ b/composer.10.json
@@ -33,7 +33,8 @@
             "oomphinc/composer-installers-extender": true,
             "phpstan/extension-installer": true,
             "php-http/discovery": true,
-            "simplesamlphp/composer-module-installer": true
+            "simplesamlphp/composer-module-installer": true,
+            "tbachert/spi": true
         }
     },
     "autoload": {

--- a/composer.10.json
+++ b/composer.10.json
@@ -33,8 +33,8 @@
             "oomphinc/composer-installers-extender": true,
             "phpstan/extension-installer": true,
             "php-http/discovery": true,
-            "simplesamlphp/composer-module-installer": true,
-            "tbachert/spi": true
+            "tbachert/spi": true,
+            "simplesamlphp/composer-module-installer": true
         }
     },
     "autoload": {


### PR DESCRIPTION
The plugin tbachert/spi is not required as part of open-telemetry/sdk

[open-telemetry/sdk - Packagist](https://packagist.org/packages/open-telemetry/sdk)  which is part of Drupal core.

Adding this plugin to allowed plugins.