### PR TITLE
fix: use latest CI image for new PaaS provisions

### DIFF
--- a/.gitlab-ci.paas.yml
+++ b/.gitlab-ci.paas.yml
@@ -1,4 +1,6 @@
 # This file is locked for GovCMS SaaS.
+image: gitlab-registry-production.govcms.amazee.io/govcms/images/ci${GOVCMS_CI_IMAGE_VERSION}
+
 include:
 
   # Simple control of your jobs.


### PR DESCRIPTION
New PaaS provisions currently fail since they use the legacy CI image (govcms/govcms-ci) and therefore Pipelines fail due to not having the latest PHP version. This change allows them to work again.