### PR TITLE
[DEVOPS-301] Make testing services optional.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -6,7 +6,7 @@ commands:
     usage: Build project.
     cmd: |
       docker compose up -d "$@" &&
-      docker compose exec -T test dockerize -wait tcp://mariadb:3306 -timeout 2m &&
+      docker compose exec -T cli dockerize -wait tcp://mariadb:3306 -timeout 2m &&
       ahoy info;
 
   down:
@@ -26,7 +26,7 @@ commands:
     usage: Build project.
     cmd: |
       docker compose up -d --build "$@" &&
-      docker compose exec -T test dockerize -wait tcp://mariadb:3306 -timeout 2m &&
+      docker compose exec -T cli dockerize -wait tcp://mariadb:3306 -timeout 2m &&
       ahoy govcms-deploy && ahoy info;
 
   cli:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,22 +66,6 @@ services:
     volumes_from: ### Local overrides to mount host SSH keys. Automatically removed in CI.
       - container:amazeeio-ssh-agent ### Local overrides to mount host SSH keys. Automatically removed in CI.
 
-  test:
-    build:
-      context: .
-      dockerfile: .docker/Dockerfile.test
-      args:
-        CLI_IMAGE: *lagoon-project
-        GOVCMS_IMAGE_VERSION: *govcms-image-version
-        SITE_AUDIT_VERSION: ${SITE_AUDIT_VERSION:-7.x-3.x}
-    labels:
-      lagoon.type: none
-    << : *default-volumes
-    depends_on:
-      - cli
-    environment:
-      << : *default-environment
-
   nginx:
     build:
       context: .
@@ -151,15 +135,33 @@ services:
   #   environment:
   #     << : *default-environment
 
-  chrome:
-    image: selenium/standalone-chrome:4.5.2-20221021
-    shm_size: '1gb'
-    platform: linux/amd64
-    depends_on:
-      - test
-    labels:
-      lagoon.type: none
-    << : *default-volumes
+  # # Uncomment to enable test.
+  # test:
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Dockerfile.test
+  #     args:
+  #       CLI_IMAGE: *lagoon-project
+  #       GOVCMS_IMAGE_VERSION: *govcms-image-version
+  #       SITE_AUDIT_VERSION: ${SITE_AUDIT_VERSION:-7.x-3.x}
+  #   labels:
+  #     lagoon.type: none
+  #   << : *default-volumes
+  #   depends_on:
+  #     - cli
+  #   environment:
+  #     << : *default-environment
+
+  # # Uncomment to enable chrome.
+  # chrome:
+  #   image: selenium/standalone-chrome:4.5.2-20221021
+  #   shm_size: '1gb'
+  #   platform: linux/amd64
+  #   depends_on:
+  #     - test
+  #   labels:
+  #     lagoon.type: none
+  #   << : *default-volumes
 
 networks:
   amazeeio-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,7 @@ services:
   #   environment:
   #     << : *default-environment
 
-  # # Uncomment to enable test.
+  # Uncomment to enable testing.
   # test:
   #   build:
   #     context: .
@@ -152,7 +152,7 @@ services:
   #   environment:
   #     << : *default-environment
 
-  # # Uncomment to enable chrome.
+  # Uncomment to enable chrome.
   # chrome:
   #   image: selenium/standalone-chrome:4.5.2-20221021
   #   shm_size: '1gb'


### PR DESCRIPTION
# Issue
The scaffold ships with two container definitions that increase the start time of the docker compose stack. These are used only by a handful of customers. To reduce the pipeline consumption usage by projects, we should make these opt-in only.

# Proposed solution
Comment out the services and adjust the build commands.