### PR TITLE
Regression fix: allow multiple docker projects of the same govcms project at the same time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # This value intentionally matches the project name on Lagoon.
 # It is used to name the CLI_IMAGE to use as a build arg locally.
 x-lagoon-project: &lagoon-project
-  {{ GOVCMS_PROJECT_NAME }}
+  ${COMPOSE_PROJECT_NAME:-{{ GOVCMS_PROJECT_NAME }}}
 
 x-lagoon-local-dev-url: &lagoon-local-dev-url
   http://{{ GOVCMS_PROJECT_NAME }}.docker.amazee.io
@@ -53,7 +53,6 @@ services:
         GOVCMS_IMAGE_VERSION: *govcms-image-version
         GOVCMS_GITHUB_TOKEN: ${GOVCMS_GITHUB_TOKEN:-}
     image: *lagoon-project
-    container_name: *lagoon-project
     labels:
       lagoon.type: cli-persistent
       lagoon.persistent.name: nginx


### PR DESCRIPTION
Due to the `container_name` in the `docker-compose.yml` for the service `cli` not being dynamic (or absent which infers it being dynamic automatically), if i run two two of the same govcms projects with the same name, I get a naming conflict.

Preferred solution: use `additional_contexts` to container depending locally on each other.
@see https://docs.docker.com/compose/how-tos/dependent-images/#use-another-services-image-as-the-base-image

Quick fix solution (this PR):
-> Remove  `container_name` (so its dynamic)
-> Set image name to be dynamic so other dependancies so the new image name built. (not preferred because `docker compose build --pull` breaks.