### PR TITLE
Ensure base image is clean to prevent orphan files persisting.

### DIFF
--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -8,4 +8,7 @@ ARG GOVCMS_IMAGE_VERSION={{ GOVCMS_VERSION }}.x-latest
 FROM ${CLI_IMAGE} as cli
 FROM govcms/php:${GOVCMS_IMAGE_VERSION}
 
+# Clean up base image so as not to conflict with any changes.
+RUN rm -rf /app
+
 COPY --from=cli /app /app

--- a/.version.yml
+++ b/.version.yml
@@ -5,4 +5,4 @@
 # e.g. site audits, automated backups.
 version: {{ GOVCMS_VERSION }}
 type: {{ GOVCMS_TYPE }}
-scaffold: 3.7.0
+scaffold: 3.7.1


### PR DESCRIPTION
The CLI image already cleanses the base image prior to running composer install, however the php image does not.

This means the PHP image could have orphaned files in the /app dir left behind that exist in the upstream base image that should not exist after the CLI image contents are copied across.