### PR TITLE
Rewriting the README.md file upon project initialisation

### DIFF
--- a/scripts/scaffold-init.sh
+++ b/scripts/scaffold-init.sh
@@ -125,7 +125,7 @@ cat > "$REPO_ROOT/README.md" << EOF
 - **Project:** $GOVCMS_NAME
 - **Version:** $GOVCMS_VERSION
 - **SaaS or PaaS:** $GOVCMS_TYPE
-- **Local Dev URL:** [http://$GOVCMS_TYPE.docker.amazee.io/](http://$GOVCMS_TYPE.docker.amazee.io/)
+- **Local Dev URL:** [http://$GOVCMS_NAME.docker.amazee.io/](http://$GOVCMS_NAME.docker.amazee.io/)
 
 ## Useful links
 

--- a/scripts/scaffold-init.sh
+++ b/scripts/scaffold-init.sh
@@ -135,10 +135,12 @@ cat > "$REPO_ROOT/README.md" << EOF
 
 ## Basic commands
 
-- \`ahoy build\`
-- \`ahoy up\`
-- \`ahoy stop\`
-- \`ahoy pull\`
+To find a list of all ahoy commands, check the .ahoy.yml file, or run \`ahoy\` in command line.
+
+- \`ahoy build\` - Builds your project containers from scratch
+- \`ahoy install\` - Only needs to be run once after the initial \`ahoy build\`
+- \`ahoy up\` - Starts your project if it has been stopped
+- \`ahoy stop\` - Stops your project
 
 ## Theme settings
 

--- a/scripts/scaffold-init.sh
+++ b/scripts/scaffold-init.sh
@@ -116,6 +116,37 @@ if [[ "$GOVCMS_TYPE" == "saas" ]]; then
   rm .docker/Dockerfile.solr.saasplus
 fi
 
+# Write project README.md
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+cat > "$REPO_ROOT/README.md" << EOF
+# $GOVCMS_NAME
+
+- **Project:** $GOVCMS_NAME
+- **Version:** $GOVCMS_VERSION
+- **SaaS or PaaS:** $GOVCMS_TYPE
+- **Local Dev URL:** [http://$GOVCMS_TYPE.docker.amazee.io/](http://$GOVCMS_TYPE.docker.amazee.io/)
+
+## Useful links
+
+- [Govcms.gov.au](https://govcms.gov.au)
+- [Statuspage](https://status.govcms.gov.au)
+- [Service desk](https://support.govcms.gov.au)
+
+## Basic commands
+
+- \`ahoy build\`
+- \`ahoy up\`
+- \`ahoy stop\`
+- \`ahoy pull\`
+
+## Theme settings
+
+Use this area to provide any additional information regarding your theme, such as if you are using a CSS compiler or any NPM packages that need to be installed.
+EOF
+
+echo "[info]: README.md updated"
+
 rm scripts/scaffold-init.sh
 
 # trap finish EXIT


### PR DESCRIPTION
Once a project is initialises, the existing README.md file becomes useless, as it only contains instructions on how to run ahoy init.

This update replaces the README.md file with project specific information as well as useful links.

**Original README.md**
<img width="869" height="594" alt="readme-original" src="https://github.com/user-attachments/assets/d749e2d1-a3f6-4e96-8523-e1b077b861cc" />

**Updated README.md**
<img width="856" height="623" alt="readme-updated-2" src="https://github.com/user-attachments/assets/e34e1d76-5372-4ee7-a7b6-d97e6f4ffa01" />
