### PR TITLE
[GOVCMS-14555] Added HTTPAV identifier.

### DIFF
--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -8,7 +8,13 @@ ARG GOVCMS_IMAGE_VERSION={{ GOVCMS_VERSION }}.x-latest
 FROM ${CLI_IMAGE} as cli
 FROM govcms/php:${GOVCMS_IMAGE_VERSION}
 
+ARG LAGOON_PROJECT
+ARG LAGOON_ENVIRONMENT
+
 # Clean up base image so as not to conflict with any changes.
 RUN rm -rf /app
 
 COPY --from=cli /app /app
+
+# Define HTTPAV identifier.
+ENV HTTPAV_IDENTIFIER=${LAGOON_PROJECT}-${LAGOON_ENVIRONMENT}


### PR DESCRIPTION
# Issue
HTTPAV Drupal module [has support](https://git.drupalcode.org/project/httpav/-/merge_requests/10/diffs#07c0fd262d6416a2866af7c75c783307659df88f_215_275) of `X-Requester-ID` header. If set, this header is then used by the AV service to supplement logs to better identify which environment instance the logs belong to.  Currently, it is impossible to correlate the logs to instances.

The value of the header is controlled via `HTTPAV_IDENTIFIER` environment variable, which is currently not set for any of instances on GovCMS.

# Proposed solution
Enhance PHP dockerfile to define `HTTPAV_IDENTIFIER` as a concatenation of existing `LAGOON_PROJECT` and `LAGOON_ENVIRONMENT` vars (e.g. `projectName-develop`), which will provide a meaningful information to the logs to identify the instance when invoking the AV service.
