### PR TITLE
fix: remove GitHub VCS repo and make token optional

### DIFF
--- a/.docker/Dockerfile.paas
+++ b/.docker/Dockerfile.paas
@@ -15,7 +15,10 @@ ENV WEBROOT=web
 RUN mv /app/web/sites/all/modules /scaffold_modules \
   && rm -rf /app
 
-RUN composer config --global github-oauth.github.com $GOVCMS_GITHUB_TOKEN
+# Only set GitHub token if it is available, otherwise skip so build doesn't fail.
+RUN if [ -n "$GOVCMS_GITHUB_TOKEN" ]; then \
+      composer config --global github-oauth.github.com "$GOVCMS_GITHUB_TOKEN"; \
+    fi
 
 COPY composer.* /app/
 COPY scripts /app/scripts

--- a/composer.11.json
+++ b/composer.11.json
@@ -6,8 +6,7 @@
     "repositories": [
         { "type": "path", "url": "custom/composer" },
         { "type": "composer", "url": "https://packages.drupal.org/8" },
-        { "type": "composer", "url": "https://asset-packagist.org" },
-        { "type": "vcs", "url": "git@github.com:govcms/govcms.git" }
+        { "type": "composer", "url": "https://asset-packagist.org" }
     ],
     "require": {
         "php": "^8.3",


### PR DESCRIPTION
# Description

Internal ticket: [GOVCMS-14815](https://osbfinance.atlassian.net/browse/GOVCMS-14815)

This PR removes the github vcs repository since it is redundant, and also makes the setting of the `GOVCMS_GITHUB_TOKEN` optional at build time.

This token is required because Packagist functions only as a metadata index and does not host packages directly. Composer frequently falls back to the GitHub HTTP API to resolve refs, fetch composer.json files, and download package distributions for non-Drupal dependencies (Symfony, Doctrine, Guzzle, etc.). Anonymous GitHub API access is limited to 60 requests per hour per IP, which is sufficient for local development but causes rate limit failures in shared environments (like GovCMS) where multiple builds share the same egress IP. 

GovCMS sets this variable in production on project provisioning so customers do not have to perform this task. Locally however, there is no need for them to set this token.

