### PR TITLE
fix: ignore .env file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@ vendor
 web/sites/default/files
 web/core/tests
 web/modules/contrib/webform/tests
+
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ docker-compose.override.yml
 
 # Local data directory.
 .data
+
+# Environment file
+.env
+
+# Mac-specific file
+.DS_STORE


### PR DESCRIPTION
# Description

Internal ticket: [GOVCMS-9617](https://osbfinance.atlassian.net/browse/GOVCMS-9617)

It is best practice for `.env` files to be git and docker ignored. This PR does that.

Also adds `.DS_STORE` to the list of gitignored files, since this is another common file that sneaks into repositories.