### PR TITLE
[GOVCMS-9962] Removed platform specification from mariadb service.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,6 @@ services:
 
   mariadb:
     image: ${MARIADB_DATA_IMAGE:-govcms/mariadb-drupal:{{ GOVCMS_VERSION }}.x-latest}
-    platform: linux/amd64
     labels:
       lagoon.type: mariadb
       lagoon.image: govcms/mariadb-drupal:{{ GOVCMS_VERSION }}.x-latest


### PR DESCRIPTION
# Issue
The `platform` for `mariadb` service is currently pinned to `amd64`. With multi-arch [support enabled for database image task](https://github.com/uselagoon/database-image-task/pull/52), this should be removed.

# Proposed solution
Remove pinned `amd64` specification.